### PR TITLE
fix: wrong rowHeight after DnD (fix #1438)

### DIFF
--- a/packages/toast-ui.grid/src/dispatch/data.ts
+++ b/packages/toast-ui.grid/src/dispatch/data.ts
@@ -69,6 +69,7 @@ import {
   forceValidateUniquenessOfColumn,
 } from '../store/helper/validation';
 import { setColumnWidthsByText, setAutoResizingColumnWidths } from './column';
+import { fitRowHeightWhenMovingRow } from './renderState';
 
 function updateHeightsWithFilteredData(store: Store) {
   if (store.data.filters) {
@@ -719,6 +720,8 @@ export function moveRow(store: Store, rowKey: RowKey, targetIndex: number) {
     rawData.splice(targetIndex, 0, rawRow);
   });
   viewData.splice(targetIndex, 0, viewRow);
+
+  fitRowHeightWhenMovingRow(store, currentIndex, targetIndex);
 
   resetSortKey(data, minIndex);
   updateRowNumber(store, minIndex);

--- a/packages/toast-ui.grid/src/view/bodyArea.tsx
+++ b/packages/toast-ui.grid/src/view/bodyArea.tsx
@@ -32,7 +32,6 @@ import GridEvent from '../event/gridEvent';
 import { getEventBus, EventBus } from '../event/eventBus';
 import { RIGHT_MOUSE_BUTTON } from '../helper/constant';
 import { isFocusedCell } from '../query/focus';
-import { matchRowHeight } from '../dispatch/renderState';
 
 interface OwnProps {
   side: Side;
@@ -174,8 +173,6 @@ class BodyAreaComp extends Component<Props> {
         this.movedIndexInfo = { index, rowKey: rowKeyToMove, appended: false };
         this.props.dispatch('moveRow', rowKey, index);
       }
-
-      matchRowHeight(this.context.store);
 
       const gridEvent = new GridEvent({
         rowKey,


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

- Related issue: #1438
- Fix the problem that rowHeight was wrong after DnD.
  - Adjust the height of the row displayed while dragging.

**As-Is**
![](https://user-images.githubusercontent.com/41339744/137088966-e8798e6b-77fc-48b0-b6b3-155d1d74850a.gif)


**To-Be**
![](https://user-images.githubusercontent.com/41339744/137089001-ef6d3c02-67c7-413c-9879-475795f84e62.gif)

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
